### PR TITLE
fix global function without parameter,compile fail

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -2054,7 +2054,7 @@ class Compiler
 
             $headerPrinter->output('PHP_FUNCTION(' . $funcName . ');');
             $parameters = $func->getParameters();
-            if (count($parameters)) {
+            if ($parameters != null && count($parameters)) {
                 $headerPrinter->output(
                     'ZEND_BEGIN_ARG_INFO_EX(' . $argInfoName . ', 0, 0, ' .
                     $func->getNumberOfRequiredParameters() . ')'


### PR DESCRIPTION
Error: Call to a member function getParameters() on null in /../zephir/Library/Compiler.php on line 2019